### PR TITLE
Add missing -R options on setfacl

### DIFF
--- a/lib/capistrano/tasks/file-permissions.rake
+++ b/lib/capistrano/tasks/file-permissions.rake
@@ -42,7 +42,7 @@ namespace :deploy do
 
         entries = entries.join(',')
 
-        execute :setfacl, "-m", entries, *paths
+        execute :setfacl, "-Rm", entries, *paths
         execute :setfacl, "-Rdm", entries, *paths
       end
     end


### PR DESCRIPTION
According to [this problem](http://serverfault.com/q/670788/270824), `-R` option must be present to ensure full files permissions.

Can you please submit a new stable version after merge this PR?

Thanks.