### PR TITLE
Use -n option of setfacl

### DIFF
--- a/lib/capistrano/tasks/file-permissions.rake
+++ b/lib/capistrano/tasks/file-permissions.rake
@@ -42,8 +42,8 @@ namespace :deploy do
 
         entries = entries.join(',')
 
-        execute :setfacl, "-Rm", entries, *paths
-        execute :setfacl, "-Rdm", entries, *paths
+        execute :setfacl, "-Rnm", entries, *paths
+        execute :setfacl, "-Rndm", entries, *paths
       end
     end
 


### PR DESCRIPTION
Previous PR #5 was not completely successful.

I propose to add `-n` option to avoid effective right re-calculation that can be made on some systems.

It's suggered on Symfony docs: http://symfony.com/doc/current/book/installation.html ("3. Using ACL on a system that does not support chmod +a")

```
       -n, --no-mask
           Do not recalculate the effective rights mask. The default  behavior
           of  setfacl  is  to  recalculate  the ACL mask entry, unless a mask
           entry was explicitly given.  The mask entry is set to the union  of
           all  permissions  of the owning group, and all named user and group
           entries. (These are  exactly  the  entries  affected  by  the  mask
           entry).
```

Source: http://linuxcommand.org/man_pages/setfacl1.html