### PR TITLE
Do not use -n flag with setfacl

### DIFF
--- a/lib/capistrano/tasks/file-permissions.rake
+++ b/lib/capistrano/tasks/file-permissions.rake
@@ -42,8 +42,8 @@ namespace :deploy do
 
         entries = entries.map { |e| "-m #{e}" }.join(' ')
 
-        execute :setfacl, "-Rn", entries, *paths
-        execute :setfacl, "-dRn", entries, *paths.map
+        execute :setfacl, "-R", entries, *paths
+        execute :setfacl, "-dR", entries, *paths.map
       end
     end
 


### PR DESCRIPTION
In symfony docs they don't use -n flag:
http://symfony.com/doc/current/book/installation.html#checking-symfony-application-configuration-and-setup
A bit more on the issue:
https://github.com/symfony/symfony-docs/issues/3712
