### PR TITLE
Added ability to modify the other ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The gem makes the following configuration variables available (shown with defaul
 
 ```ruby
 set :file_permissions_roles, :all
+set :file_permissions_modify_other, false
 set :file_permissions_paths, []
 set :file_permissions_users, []
 set :file_permissions_groups, []

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ release, this gem would execute the following:
 [..] setfacl -Rn -m u:www-data:rwX -m u:<deploy-user>:rwX <path-to-app>/shared/app/logs <path-to-app>/<release>/app/cache
 ```
 
+Additionally, if you were interested in modifying the `other` ACL, setting `file_permissions_modify_other` to `true` would do the following:
+```
+[..] setfacl -Rn -m u:www-data:rwX -m u:<deploy-user>:rwX -m o::rwX <path-to-app>/shared/app/logs <path-to-app>/<release>/app/cache
+```
+
 ### Other tasks
 * deploy:set_permissions:chmod
 * deploy:set_permissions:chgrp

--- a/lib/capistrano/tasks/file-permissions.rake
+++ b/lib/capistrano/tasks/file-permissions.rake
@@ -40,6 +40,10 @@ namespace :deploy do
           entries.push(*acl_entries(fetch(:file_permissions_groups), 'g'))
         end
 
+        if fetch(:file_permissions_modify_other)
+          entries.push(*acl_entries([''], 'o'))
+        end
+
         entries = entries.map { |e| "-m #{e}" }.join(' ')
 
         execute :setfacl, "-R", entries, *paths
@@ -94,6 +98,7 @@ end
 namespace :load do
   task :defaults do
     set :file_permissions_roles, :all
+    set :file_permissions_modify_other, false
     set :file_permissions_paths, []
     set :file_permissions_users, []
     set :file_permissions_groups, []


### PR DESCRIPTION
In the seldom cases when we want to modify the `other` ACL with file-permissions, setting `file_permissions_modify_other` as true would allow us to do so.