### PR TITLE
Friendlier group permissions

### DIFF
--- a/lib/capistrano/tasks/file-permissions.rake
+++ b/lib/capistrano/tasks/file-permissions.rake
@@ -51,7 +51,7 @@ namespace :deploy do
     task :chmod => [:check] do
       next unless any? :file_permissions_paths
       on roles fetch(:file_permissions_roles) do |host|
-        execute :chmod, "-R", fetch(:file_permissions_chmod_mode), *absolute_writable_paths
+        execute sudo:, :chmod, "-R", fetch(:file_permissions_chmod_mode), *absolute_writable_paths
       end
     end
 
@@ -84,8 +84,8 @@ namespace :deploy do
       on roles fetch(:file_permissions_roles) do |host|
         paths = absolute_writable_paths
         execute :sudo, :chgrp, "-R", groups.first, *paths
-        # make sure all child directories inherit group writable
-        execute :sudo, :chmod, "-R", "g+rws", *paths
+	# ensure full perms to group 
+        execute :sudo, :chmod, "-R", "g+rwx", *paths
       end
     end
   end

--- a/lib/capistrano/tasks/file-permissions.rake
+++ b/lib/capistrano/tasks/file-permissions.rake
@@ -85,7 +85,7 @@ namespace :deploy do
         paths = absolute_writable_paths
         execute :sudo, :chgrp, "-R", groups.first, *paths
         # make sure all child directories inherit group writable
-        execute :sudo, :chmod, "-R", "g+rws", *paths
+        execute :sudo, :chmod, "-R", "g+rwsx", *paths
       end
     end
   end

--- a/lib/capistrano/tasks/file-permissions.rake
+++ b/lib/capistrano/tasks/file-permissions.rake
@@ -85,7 +85,7 @@ namespace :deploy do
         paths = absolute_writable_paths
         execute :sudo, :chgrp, "-R", groups.first, *paths
         # make sure all child directories inherit group writable
-        execute :sudo, :chmod, "-R", "g+rwsx", *paths
+        execute :sudo, :chmod, "-R", "g+rws", *paths
       end
     end
   end
@@ -97,6 +97,6 @@ namespace :load do
     set :file_permissions_paths, []
     set :file_permissions_users, []
     set :file_permissions_groups, []
-    set :file_permissions_chmod_mode, "0777"
+    set :file_permissions_chmod_mode, "0770"
   end
 end

--- a/lib/capistrano/tasks/file-permissions.rake
+++ b/lib/capistrano/tasks/file-permissions.rake
@@ -51,7 +51,7 @@ namespace :deploy do
     task :chmod => [:check] do
       next unless any? :file_permissions_paths
       on roles fetch(:file_permissions_roles) do |host|
-        execute sudo:, :chmod, "-R", fetch(:file_permissions_chmod_mode), *absolute_writable_paths
+        execute :chmod, "-R", fetch(:file_permissions_chmod_mode), *absolute_writable_paths
       end
     end
 


### PR DESCRIPTION
having an sticky bit seems unnecessary as it will enforce having those permissions set up and avoids deletion and mv's from groups users, since first run until root/owner comes and modifies them which is not something you always want, group should be able to modify those perms and children directories permissions too.

i would suggest to remove that line entirely but since it would block the user to make any further modifications too i think this is a better solution.

directories require execute permission to be able to ```cd /dir``` so execute permission should also be added.

also, defaulting to full perms to all linux users seems insecure, so 0770 seems like a better solution.
