### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/capistrano-file-permissions.gemspec
+++ b/capistrano-file-permissions.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{File permissions management for Capistrano 3.x}
   spec.summary       = %q{File permissions management for Capistrano 3.x}
   spec.homepage      = 'https://github.com/capistrano/file-permissions'
+  spec.metadata      = { "rubygems_mfa_required" => "true" }
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations
by any of the owners require OTP.

Ref capistrano/capistrano#2189